### PR TITLE
Update readme to include new SPI subsets + SPI wishlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ _pyspi_ is a comprehensive python library for computing statistics of pairwise i
 The code provides easy access to hundreds of methods for evaluating the relationship between pairs of time series, from simple statistics (like correlation) to advanced multi-step algorithms (like Granger causality).
 The code is licensed under the [GNU GPL v3 license](http://www.gnu.org/licenses/gpl-3.0.html) (or later).
 
-**Feel free to [email me](mailto:oliver.m.cliff@gmail.com) for help with real-world applications.**
-Feedback is much appreciated through email, [issues](https://github.com/olivercliff/pyspi/issues), or [pull requests](https://github.com/olivercliff/pyspi/pulls).
+**Feel free to reach out for help with real-world applications.**
+Feedback is much appreciated through [issues](https://github.com/DynamicsAndNeuralSystems/pyspi/issues), or [pull requests](https://github.com/DynamicsAndNeuralSystems/pyspi/pulls).
 
 ## Acknowledgement
 
 If you use this code, please cite the following preprint:
 
-Oliver M. Cliff, Annie G. Bryant, Joseph T. Lizier, Naotsugu Tsuchiya, Ben D. Fulcher, "Unifying Pairwise Interactions in Complex Dynamics," _arXiv_ preprint, [arXiv:2201.11941v2](https://arxiv.org/abs/2201.11941v2) (2023).
+Oliver M. Cliff, Annie G. Bryant, Joseph T. Lizier, Naotsugu Tsuchiya, Ben D. Fulcher, "Unifying Pairwise Interactions in Complex Dynamics," _arXiv_ preprint, [arXiv:2201.11941](https://arxiv.org/abs/2201.11941) (2023).
 
 ## Getting Started
 
@@ -27,7 +27,7 @@ Once you're done, you can learn how to use the package by checking out the:
 - [Tutorial (finance: stock price time series)](https://github.com/olivercliff/pyspi/blob/main/demos/tutorial.ipynb)
 - [Tutorial (neuroimaging: fMRI time series)](https://github.com/anniegbryant/CNS_2022/blob/main/pyspi_tutorial/CNS2022_pyspi_demo.ipynb).
 
-If you have access to a PBS cluster and are processing MTS with many processes (or are analyzing many MTS), then you may find the [_pyspi_ distribute](https://github.com/olivercliff/pyspi-distribute) repository helpful.
+If you have access to a PBS cluster and are processing MTS with many processes (or are analyzing many MTS), then you may find the [_pyspi_ distribute](https://github.com/DynamicsAndNeuralSystems/pyspi-distribute) repository helpful.
 
 If your dataset is large (containing many processes and/or observations), you can use a pre-configured set of reduced statistics or create your own subsets (cf. the [documentation guide](https://pyspi-toolkit.readthedocs.io/en/latest/advanced.html#using-a-reduced-spi-set)).
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,4 @@ If your dataset is large (containing many processes and/or observations), you ca
 
 ## SPI Wishlist
 
-As _pyspi_ is under active development, we maintain a list of statistics that we wish to add to the library going forward -- and welcome suggestions from users by submitting an Issue.
-At the moment, here are some SPIs we hope to incorporate in the future: 
-
-* Gromov-Wasserstain distance for time series (*GW<sub>τ</sub>*), as described in [Kravtsova et al. (2023)](https://doi.org/10.1007/s11538-023-01175-y)
+As _pyspi_ is under active development, we are always open to suggestions for new SPIs to be added via the [projects tab](https://github.com/DynamicsAndNeuralSystems/pyspi/projects) in this repo. 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Feedback is much appreciated through email, [issues](https://github.com/olivercl
 
 If you use this code, please cite the following preprint:
 
-Oliver M. Cliff, Joseph T. Lizier, Naotsugu Tsuchiya, Ben D. Fulcher, "Unifying Pairwise Interactions in Complex Dynamics," _arXiv_ preprint, [arXiv:2201.11941](https://arxiv.org/abs/2201.11941) (2022).
+Oliver M. Cliff, Annie G. Bryant, Joseph T. Lizier, Naotsugu Tsuchiya, Ben D. Fulcher, "Unifying Pairwise Interactions in Complex Dynamics," _arXiv_ preprint, [arXiv:2201.11941v2](https://arxiv.org/abs/2201.11941v2) (2023).
 
 ## Getting Started
 
@@ -29,7 +29,7 @@ Once you're done, you can learn how to use the package by checking out the:
 
 If you have access to a PBS cluster and are processing MTS with many processes (or are analyzing many MTS), then you may find the [_pyspi_ distribute](https://github.com/olivercliff/pyspi-distribute) repository helpful.
 
-If your dataset is large (containing many processes and/or observations), you can use a reduced set of statistics by instantiating the calculator with the `fast=True` parameter (cf. the [simple demo](https://github.com/olivercliff/pyspi/blob/main/demos/simple_demo.py)).
+If your dataset is large (containing many processes and/or observations), you can use a pre-configured set of reduced statistics or create your own subsets (cf. the [documentation guide](https://pyspi-toolkit.readthedocs.io/en/latest/advanced.html#using-a-reduced-spi-set)).
 
 ## Other highly comparative toolboxes
 
@@ -40,3 +40,10 @@ If your dataset is large (containing many processes and/or observations), you ca
 ### _hcga_
 
 [_hcga_](https://github.com/barahona-research-group/hcga), a *highly comparative graph analysis* toolkit, computes several thousands of graph features directly from any given network.
+
+## SPI Wishlist
+
+As _pyspi_ is under active development, we maintain a list of statistics that we wish to add to the library going forward -- and welcome suggestions from users by submitting an Issue.
+At the moment, here are some SPIs we hope to incorporate in the future: 
+
+* Gromov-Wasserstain distance for time series (*GW<sub>τ</sub>*), as described in [Kravtsova et al. (2023)](https://doi.org/10.1007/s11538-023-01175-y)

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -73,7 +73,7 @@ Then use the calculator as normal (see :ref:`Usage`).
 
 .. note::
     We have provided a detailed list of many of the statistics included in this toolkit (and the configuration file) in the Supplementary Material of our `preprint <https://arxiv.org/abs/2201.11941>`_, and will include an up-to-date list of statistics in this documentation shortly.
-    However, if you have any questions about a particular implementation, do not hesitate to `contact me <mailto:oliver.cliff@sydney.edu.au>`_ for any assistance.
+    However, if you have any questions about a particular implementation, do not hesitate to raise an issue in the `github repo <https://github.com/DynamicsAndNeuralSystems/pyspi>`_ for any assistance.
 
 Using the toolkit without Octave
 --------------------------------

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -28,7 +28,21 @@ If you want more control over how the MTS are treated upon input, you can direct
 Using a reduced SPI set
 -----------------------
 
-You can easily use a subset of the SPIs by copying a version of the :code:`config.yaml` file to a local directory and removing those you don't want the calculator to compute.
+The :class:`~pyspi.calculator.Calculator` object computes 283 SPIs by default, but you may only be interested in a subset of these.
+We provide three pre-configured reduced SPI subsets that you may wish to try:
+
+* :code:`fast`: Most SPIs (excluding those that are computationally expensive)
+* :code:`sonnet` - 14 SPIs, one from each of the data-driven clusters as described in `Cliff et al. (2023) <https://arxiv.org/abs/2201.11941>`_
+* :code:`fabfour` - 4 SPIs that are simple and computationally efficient: Pearson correlation, Spearman correlation, directed information with a Gaussian density estimator, and the power envelope correlation.
+
+You may specify any one of these subsets when you instantiate the :code:`Calculator` object:
+
+.. code-block::
+
+    from pyspi.calculator import Calculator
+    calc = Calculator(dataset=dataset, subset='sonnet')
+
+Alternatively, if you would like to use your own bespoke set of SPIs, you can copy a version of the :code:`config.yaml` file to your workspace and edit it to remove any SPIs that you would not like the :code:`Calculator` to compute.
 First, copy the :code:`config.yaml` file to your workspace:
 
 .. code-block:: console

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -36,8 +36,8 @@ And, using only the :meth:`~pyspi.calculator.Calculator.compute` method, we can 
 
 .. note::
    While we tried to make the calculator as efficient as possible, computing all statistics can take a while (depending on the size of your dataset).
-   You can use a faster set of statistics by instantiating the calculator with :code:`fast=True`, see :class:`~pyspi.calculator.Calculator`.
-   Alternatively, design your own subset of the statistics by following the instructions in :ref:`Using a reduced SPI set`.
+   You can use a faster set of statistics by instantiating the calculator with :code:`subset=fast`, see :class:`~pyspi.calculator.Calculator`.
+   We also provide a reduced set of statistics that are useful for many applications, with the option for users to design their own subset of statistics; see :ref:`Using a reduced SPI set`.
 
 Once the calculator has computed each of the statistics, you can access all values using the :attr:`~pyspi.calculator.Calculator.table` property:
 

--- a/pyspi/calculator.py
+++ b/pyspi/calculator.py
@@ -39,7 +39,7 @@ class Calculator:
     """
 
     def __init__(
-        self, dataset=None, name=None, labels=None, fast=False, sonnet=False, configfile=None
+        self, dataset=None, name=None, labels=None, fast=False, sonnet=False, fabfour=False, configfile=None
     ):
         self._spis = {}
 
@@ -51,6 +51,10 @@ class Calculator:
             elif sonnet is True:
                 configfile = (
                     os.path.dirname(os.path.abspath(__file__)) + "/sonnet_config.yaml"
+                )
+            elif fabfour is True:
+                configfile = (
+                    os.path.dirname(os.path.abspath(__file__)) + "/fabfour_config.yaml"
                 )
             else:
                 configfile = os.path.dirname(os.path.abspath(__file__)) + "/config.yaml"

--- a/pyspi/calculator.py
+++ b/pyspi/calculator.py
@@ -41,6 +41,7 @@ class Calculator:
     ):
         self._spis = {}
 
+        # Define configfile by subset if it was not specified
         if configfile is None:
             if subset == "fast":
                 configfile = (
@@ -54,12 +55,11 @@ class Calculator:
                 configfile = (
                     os.path.dirname(os.path.abspath(__file__)) + "/fabfour_config.yaml"
                 )
-            elif subset == "fabfive":
-                # Raise error as this subset does not exist
+            # If no configfile was provided but the subset was not one of the above (or the default 'all'), raise an error
+            elif subset != "all":
                 raise ValueError(
-                    f"Subset 'fabfive' does not exist. Try 'fast', 'sonnet', or 'fabfour'."
+                    f"Subset '{subset}' does not exist. Try 'all' (default), 'fast', 'sonnet', or 'fabfour'."
                 )
-
             else:
                 configfile = os.path.dirname(os.path.abspath(__file__)) + "/config.yaml"
         self._load_yaml(configfile)

--- a/pyspi/calculator.py
+++ b/pyspi/calculator.py
@@ -30,29 +30,27 @@ class Calculator:
             The name of the calculator. Mainly used for printing the results but can be useful if you have multiple instances, defaults to None.
         labels (array_like, optional):
             Any set of strings by which you want to label the calculator. This can be useful later for classification purposes, defaults to None.
-        fast (bool, optional):
-            If True, use a hand-picked set of ~210 SPIs that compute quickly but are still relatively comprehensive, defaults to False.
-        sonnet (bool, optional):
-            If True, use a hand-picked set of 14 SPIs that represent the set of 14 hierarchical clusters of SPIs detailed in the preprint, defaults to False.
+        subset (str, optional):
+            A pre-configured subset of SPIs to use. Options are "all", "fast", "sonnet", or "fabfour", defaults to "all".
         configfile (str, optional):
-            The location of the YAML configuration file. See :ref:`Using a reduced SPI set`, defaults to :code:`'</path/to/pyspi>/pyspi/config.yaml'`
+            The location of the YAML configuration file for a user-defined subset. See :ref:`Using a reduced SPI set`, defaults to :code:`'</path/to/pyspi>/pyspi/config.yaml'`
     """
 
     def __init__(
-        self, dataset=None, name=None, labels=None, fast=False, sonnet=False, fabfour=False, configfile=None
+        self, dataset=None, name=None, labels=None, subset="all", configfile=None
     ):
         self._spis = {}
 
         if configfile is None:
-            if fast is True:
+            if subset == "fast":
                 configfile = (
                     os.path.dirname(os.path.abspath(__file__)) + "/fast_config.yaml"
                 )
-            elif sonnet is True:
+            elif subset == "sonnet":
                 configfile = (
                     os.path.dirname(os.path.abspath(__file__)) + "/sonnet_config.yaml"
                 )
-            elif fabfour is True:
+            elif subset == "fabfour":
                 configfile = (
                     os.path.dirname(os.path.abspath(__file__)) + "/fabfour_config.yaml"
                 )

--- a/pyspi/calculator.py
+++ b/pyspi/calculator.py
@@ -54,6 +54,12 @@ class Calculator:
                 configfile = (
                     os.path.dirname(os.path.abspath(__file__)) + "/fabfour_config.yaml"
                 )
+            elif subset == "fabfive":
+                # Raise error as this subset does not exist
+                raise ValueError(
+                    f"Subset 'fabfive' does not exist. Try 'fast', 'sonnet', or 'fabfour'."
+                )
+
             else:
                 configfile = os.path.dirname(os.path.abspath(__file__)) + "/config.yaml"
         self._load_yaml(configfile)

--- a/pyspi/fabfour_config.yaml
+++ b/pyspi/fabfour_config.yaml
@@ -1,0 +1,21 @@
+# Pearson and Spearman correlation statistics
+.statistics.basic:
+  # Covariance
+  Covariance:
+    - estimator: EmpiricalCovariance
+
+  # Spearman's correlation coefficient
+  SpearmanR:
+    - squared: True
+
+# Directed information with a Gaussian density estimator
+.statistics.infotheory:
+  DirectedInfo:
+    - estimator: gaussian
+
+# Power envelope correlation
+.statistics.misc:
+  PowerEnvelopeCorrelation:
+    - orth: False
+      log: False
+      absolute: False

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
     package_data={'': ['config.yaml',
                        'sonnet_config.yaml',
                         'fast_config.yaml',
+                        'fabfour_config.yaml',
                         'lib/jidt/infodynamics.jar',
                         'lib/PhiToolbox/Phi/phi_comp.m',
                         'lib/PhiToolbox/Phi/phi_star_Gauss.m',


### PR DESCRIPTION
This PR introduces a new SPI subset ('fabfour'), which includes four SPIs:

Pearson correlation
Spearman correlation
Directed information with a Gaussian density estimator
Power envelope correlation
As we now have three possible SPI subsets (fast, sonnet, fabfour), this PR also reconfigures the specification to be one argument to the Calculator object (subset) with the options of "all" (default), "fast", "sonnet", or "fabfour". The documentation has been updated to reflect this change.

The readme is also updated accordingly to reflect these subsets, as well as by starting an SPI wishlist.